### PR TITLE
Fix: Accessing Form data throws exception in not supported Content-Type

### DIFF
--- a/src/Core/Idempotency.cs
+++ b/src/Core/Idempotency.cs
@@ -196,7 +196,8 @@ namespace IdempotentAPI.Core
             }
 
             // Form-Files data:
-            if (httpRequest.Form != null
+            if (httpRequest.HasFormContentType
+                && httpRequest.Form != null
                 && httpRequest.Form.Files != null
                 && httpRequest.Form.Files.Count > 0)
             {

--- a/src/IdempotentAPI.csproj
+++ b/src/IdempotentAPI.csproj
@@ -4,12 +4,14 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Authors>Ioannis Kyriakidis</Authors>
     <Company>ikyriakidis.com</Company>
-    <Version>0.1.0-beta</Version>
+    <Version>0.2.0-beta</Version>
     <Description>IdempotentAPI is an ASP.NET Core attribute by which any HTTP write operations (POST and PATCH) can have effect only once for the given request data.</Description>
     <PackageTags>idempotent api;idempotency;asp.net core;attribute;middleware;rest</PackageTags>
     <RepositoryUrl>https://github.com/ikyriak/IdempotentAPI.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/ikyriak/IdempotentAPI</PackageProjectUrl>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/IdempotentAPI.Tests.csproj
+++ b/tests/IdempotentAPI.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Fix: Accessing Form data throws an exception when the Content-Type is not supported.