### PR TITLE
Added Feature to handle inflight requests

### DIFF
--- a/src/Core/Idempotency.cs
+++ b/src/Core/Idempotency.cs
@@ -111,7 +111,7 @@ namespace IdempotentAPI.Core
             return true;
         }
 
-        private byte[] generateRequestInFlightCacaheDataSerialied(ActionExecutingContext context)
+        private byte[] generateRequestInFlightCacaheDataSerialized(ActionExecutingContext context)
         {
             Dictionary<string, object> cacheData = new Dictionary<string, object>();
             cacheData.Add("Request.Inflight", new RequestinFlightPlaceHolder());

--- a/src/Core/Idempotency.cs
+++ b/src/Core/Idempotency.cs
@@ -54,7 +54,6 @@ namespace IdempotentAPI.Core
             _logger = logger;
         }
 
-
         private bool TryGetIdempotencyKey(HttpRequest httpRequest, out string idempotencyKey, out IActionResult errorActionResult)
         {
             idempotencyKey = string.Empty;
@@ -86,6 +85,7 @@ namespace IdempotentAPI.Core
             idempotencyKey = idempotencyKeys.ToString();
             return true;
         }
+
         private bool canPerformIdempotency(HttpRequest httpRequest)
         {
             // If distributedCache is not configured
@@ -110,6 +110,15 @@ namespace IdempotentAPI.Core
 
             return true;
         }
+
+        private byte[] generateRequestInFlightCacaheDataSerialied(ActionExecutingContext context)
+        {
+            Dictionary<string, object> cacheData = new Dictionary<string, object>();
+            cacheData.Add("Request.Inflight", new RequestinFlightPlaceHolder());
+
+            return cacheData.Serialize();
+        }
+
         private byte[] generateCacheData(ResultExecutedContext context)
         {
             Dictionary<string, object> cacheData = new Dictionary<string, object>();
@@ -168,6 +177,7 @@ namespace IdempotentAPI.Core
             // Serialize & Compress data:
             return cacheData.Serialize();
         }
+
         private string getRequestsDataHash(HttpRequest httpRequest)
         {
             List<object> requestsData = new List<object>();
@@ -258,6 +268,13 @@ namespace IdempotentAPI.Core
             Dictionary<string, object> cacheData = (Dictionary<string, object>)cacheDataSerialized.DeSerialize();
             if (cacheData != null)
             {
+                // RPG - 2021-07-05 - Check if there is a copy of this request in flight, if so return a 409 Http Conflict response
+                if(cacheData.ContainsKey("Request.Inflight") && cacheData["Request.Inflight"] is RequestinFlightPlaceHolder)
+                {
+                    context.Result = new ConflictResult();
+                    return;
+                }
+
                 // 2019-07-06: Evaluate the "Request.DataHash" in order to be sure that the cached response is returned
                 //  for the same combination of IdempotencyKey and Request
                 string cachedRequestDataHash = cacheData["Request.DataHash"].ToString();
@@ -276,7 +293,7 @@ namespace IdempotentAPI.Core
                 Type contextResultType = Type.GetType(resultObjects["ResultType"].ToString());
                 if (contextResultType == null)
                 {
-                    throw new NotImplementedException($"ApplyPreIdempotency, ResultType {resultObjects["ResultType"].ToString()} is not recornized");
+                    throw new NotImplementedException($"ApplyPreIdempotency, ResultType {resultObjects["ResultType"].ToString()} is not recognized");
                 }
 
 
@@ -313,7 +330,7 @@ namespace IdempotentAPI.Core
                 }
                 else
                 {
-                    throw new NotImplementedException($"ApplyPreIdempotency is not implement for IActionResult type {contextResultType.ToString()}");
+                    throw new NotImplementedException($"ApplyPreIdempotency is not implemented for IActionResult type {contextResultType.ToString()}");
                 }
 
                 // Include cached headers (if does not exist) at the response:
@@ -332,7 +349,15 @@ namespace IdempotentAPI.Core
                 _logger.LogInformation("IdempotencyFilterAttribute [Before Controller]: Return result from idempotency cache (of type {contextResultType})", contextResultType.ToString());
                 _isPreIdempotencyCacheReturned = true;
             }
+            else
+            {
+                _logger.LogInformation("IdempotencyFilterAttribute [Before Controller]: Add request into inflight cache");
+                DistributedCacheEntryOptions cacheOptions = new DistributedCacheEntryOptions();
+                cacheOptions.AbsoluteExpirationRelativeToNow = new TimeSpan(_expireHours, 0, 0);
 
+                byte[] requestInFlightCacaheDataSerialied = generateRequestInFlightCacaheDataSerialied(context);
+                _distributedCache.Set(DistributedCacheKey, requestInFlightCacaheDataSerialied, cacheOptions);
+            }
             _logger.LogInformation("IdempotencyFilterAttribute [Before Controller]: End");
             _isPreIdempotencyApplied = true;
         }

--- a/src/Core/Idempotency.cs
+++ b/src/Core/Idempotency.cs
@@ -355,7 +355,7 @@ namespace IdempotentAPI.Core
                 DistributedCacheEntryOptions cacheOptions = new DistributedCacheEntryOptions();
                 cacheOptions.AbsoluteExpirationRelativeToNow = new TimeSpan(_expireHours, 0, 0);
 
-                byte[] requestInFlightCacaheDataSerialied = generateRequestInFlightCacaheDataSerialied(context);
+                byte[] requestInFlightCacaheDataSerialied = generateRequestInFlightCacaheDataSerialized(context);
                 _distributedCache.Set(DistributedCacheKey, requestInFlightCacaheDataSerialied, cacheOptions);
             }
             _logger.LogInformation("IdempotencyFilterAttribute [Before Controller]: End");

--- a/src/Core/RequestinFlightPlaceHolder.cs
+++ b/src/Core/RequestinFlightPlaceHolder.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IdempotentAPI.Core
+{
+    sealed internal class RequestinFlightPlaceHolder
+    {
+    }
+}

--- a/src/Core/RequestinFlightPlaceHolder.cs
+++ b/src/Core/RequestinFlightPlaceHolder.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace IdempotentAPI.Core
 {
+    [Serializable]
     sealed internal class RequestinFlightPlaceHolder
     {
     }

--- a/tests/Filters/IdempotencyAttribute_Tests.cs
+++ b/tests/Filters/IdempotencyAttribute_Tests.cs
@@ -632,7 +632,9 @@ namespace IdempotentAPI.xUnit.Filters
 
             //Assert : Part 4
             // The result of the above should be coming from the cache so we should have a result
-            Assert.Equal(200, ((OkObjectResult)inflightExecutingContext.Result).StatusCode);       
+            Assert.Equal(typeof(OkObjectResult), inflightExecutingContext.Result.GetType());
+            Assert.Equal(typeof(ResponseModelBasic), ((OkObjectResult)inflightExecutingContext.Result).Value.GetType());                                    
+            Assert.Equal(200, ((OkObjectResult)inflightExecutingContext.Result).StatusCode);
 
         }
     }

--- a/tests/Filters/IdempotencyAttribute_Tests.cs
+++ b/tests/Filters/IdempotencyAttribute_Tests.cs
@@ -617,6 +617,7 @@ namespace IdempotentAPI.xUnit.Filters
             // Act Part 2 - since we haven't called OnResultExecuted the result of the first request should still be inflight and we should have a 409 result
             idempotencyAttributeFilterRequest2.OnActionExecuting(inflightExecutingContext);
             Assert.NotNull(inflightExecutingContext.Result);
+            Assert.Equal(typeof(ConflictResult), inflightExecutingContext.Result.GetType());
             Assert.Equal(409, ((ConflictResult)inflightExecutingContext.Result).StatusCode);
 
             // Act Part 3:

--- a/tests/Filters/IdempotencyAttribute_Tests.cs
+++ b/tests/Filters/IdempotencyAttribute_Tests.cs
@@ -563,8 +563,8 @@ namespace IdempotentAPI.xUnit.Filters
         /// Part4: Resend the same request and ensure the response is the same as part 3
         /// </summary>
         [Theory]
-        [InlineData("POST", "b8fcc234-e1bd-11e9-81b4-2a2ae2dbcce4")]
-        [InlineData("PATCH", "c45ca868-fa74-11e9-8f0b-362b9e155667")]
+        [InlineData("POST", "3e692c04-c19d-419b-b60c-3cdb6c577686")]
+        [InlineData("PATCH", "9099b60c-000d-4e83-9f9e-f342f6ad0f04")]
         public void SetInDistributionCache_IfValidRequestNotCached_WithInflight(string httpMethod, string idempotencyKey)
         {
             // Arrange


### PR DESCRIPTION
Added dummy place holder class for Inflight requests

Updated ApplyPreIdempotency to add an item to the cache if there isn't one to indicate the request in in progress.

Added a check to see if the above object exists in any following requests (to handle concurrent / long running requests) and if so return a 409 conflict.