### PR TITLE
Issue: Invalid character in chunk size error when using Kestrel

### DIFF
--- a/src/Core/Idempotency.cs
+++ b/src/Core/Idempotency.cs
@@ -39,6 +39,11 @@ namespace IdempotentAPI.Core
         private bool _isPreIdempotencyCacheReturned = false;
         private HashAlgorithm _hashAlgorithm = new SHA256CryptoServiceProvider();
 
+        /// <summary>
+        /// The read-only list of HTTP Header Keys will be handled from the selected HTTP Server and
+        /// not included in the cache.
+        /// </summary>
+        private readonly IReadOnlyList<string> _excludeHttpHeaderKeys = new List<string>() { "Transfer-Encoding" };
 
         public Idempotency(
                     IDistributedCache distributedCache,
@@ -132,7 +137,10 @@ namespace IdempotentAPI.Core
             cacheData.Add("Response.StatusCode", context.HttpContext.Response.StatusCode);
             cacheData.Add("Response.ContentType", context.HttpContext.Response.ContentType);
 
-            Dictionary<string, List<string>> Headers = context.HttpContext.Response.Headers.ToDictionary(h => h.Key, h => h.Value.ToList());
+            Dictionary<string, List<string>> Headers = context.HttpContext.Response.Headers
+                .Where(h=> !_excludeHttpHeaderKeys.Contains(h.Key))
+                .ToDictionary(h => h.Key, h => h.Value.ToList());
+
             cacheData.Add("Response.Headers", Headers);
 
 

--- a/src/IdempotentAPI.csproj
+++ b/src/IdempotentAPI.csproj
@@ -4,14 +4,14 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Authors>Ioannis Kyriakidis</Authors>
     <Company>ikyriakidis.com</Company>
-    <Version>0.2.1-beta</Version>
+    <Version>0.2.2-prerelease-01</Version>
     <Description>IdempotentAPI is an ASP.NET Core attribute by which any HTTP write operations (POST and PATCH) can have effect only once for the given request data.</Description>
     <PackageTags>idempotent api;idempotency;asp.net core;attribute;middleware;rest</PackageTags>
     <RepositoryUrl>https://github.com/ikyriak/IdempotentAPI.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/ikyriak/IdempotentAPI</PackageProjectUrl>
-    <AssemblyVersion>0.2.1.0</AssemblyVersion>
-    <FileVersion>0.2.1.0</FileVersion>
+    <AssemblyVersion>0.2.2.0</AssemblyVersion>
+    <FileVersion>0.2.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IdempotentAPI.csproj
+++ b/src/IdempotentAPI.csproj
@@ -4,14 +4,14 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Authors>Ioannis Kyriakidis</Authors>
     <Company>ikyriakidis.com</Company>
-    <Version>0.2.2-prerelease-01</Version>
+    <Version>0.2.3-beta</Version>
     <Description>IdempotentAPI is an ASP.NET Core attribute by which any HTTP write operations (POST and PATCH) can have effect only once for the given request data.</Description>
     <PackageTags>idempotent api;idempotency;asp.net core;attribute;middleware;rest</PackageTags>
     <RepositoryUrl>https://github.com/ikyriak/IdempotentAPI.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/ikyriak/IdempotentAPI</PackageProjectUrl>
-    <AssemblyVersion>0.2.2.0</AssemblyVersion>
-    <FileVersion>0.2.2.0</FileVersion>
+    <AssemblyVersion>0.2.3.0</AssemblyVersion>
+    <FileVersion>0.2.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `Transfer-Encoding` HTTP header was included in the cache when using the Kestrel server, resulting in the `Invalid character in chunk size` error.

In this fix, we introduced a list of HTTP headers (including the `Transfer-Encoding` HTTP header) to be excluded from the cache and finally handled from the HTTP Server.