### PR TITLE
Added MinimalAPI webapi project

### DIFF
--- a/IdempotentAPI.sln
+++ b/IdempotentAPI.sln
@@ -37,6 +37,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdempotentAPI.TestWebAPIs2"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdempotentAPI.TestWebAPIs1", "tests\IdempotentAPI.TestWebAPIs1\IdempotentAPI.TestWebAPIs1.csproj", "{4AAAD479-EEA2-4B9C-8709-6DD0CA1574EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdempotentAPI.TestWebAPIs3", "tests\IdempotentAPI.TestWebAPIs3\IdempotentAPI.TestWebAPIs3.csproj", "{5DA6F50E-F41A-43BB-A584-82C6B49A24B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -91,6 +93,10 @@ Global
 		{4AAAD479-EEA2-4B9C-8709-6DD0CA1574EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4AAAD479-EEA2-4B9C-8709-6DD0CA1574EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4AAAD479-EEA2-4B9C-8709-6DD0CA1574EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DA6F50E-F41A-43BB-A584-82C6B49A24B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DA6F50E-F41A-43BB-A584-82C6B49A24B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DA6F50E-F41A-43BB-A584-82C6B49A24B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DA6F50E-F41A-43BB-A584-82C6B49A24B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -108,6 +114,7 @@ Global
 		{63F0BB18-3CCA-46F8-ACA1-F3B6EC05CE5B} = {B0CA0D1D-3C22-4935-8467-310509EDB755}
 		{F3D3B42C-5582-4EFA-9ED8-C81EA767259C} = {B0CA0D1D-3C22-4935-8467-310509EDB755}
 		{4AAAD479-EEA2-4B9C-8709-6DD0CA1574EE} = {B0CA0D1D-3C22-4935-8467-310509EDB755}
+		{5DA6F50E-F41A-43BB-A584-82C6B49A24B3} = {B0CA0D1D-3C22-4935-8467-310509EDB755}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0865C8C6-957E-4E70-A784-8EBC2282E4AB}

--- a/tests/IdempotentAPI.IntegrationTests/IdempotentAPI.IntegrationTests.csproj
+++ b/tests/IdempotentAPI.IntegrationTests/IdempotentAPI.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
@@ -25,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\IdempotentAPI.TestWebAPIs1\IdempotentAPI.TestWebAPIs1.csproj" />
     <ProjectReference Include="..\IdempotentAPI.TestWebAPIs2\IdempotentAPI.TestWebAPIs2.csproj" />
+    <ProjectReference Include="..\IdempotentAPI.TestWebAPIs3\IdempotentAPI.TestWebAPIs3.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
+++ b/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
@@ -12,6 +12,9 @@ namespace IdempotentAPI.IntegrationTests.Infrastructure
         public HttpClient TestServerClient2 { get; }
         public HttpClient TestServerClient3 { get; }
         
+        public HttpClient TestServerClientRedis1 { get; }
+        public HttpClient TestServerClientRedis2 { get; }
+        
         public Fixture()
         {
             var defaultHttpClientHandler = new HttpClientHandler
@@ -55,6 +58,20 @@ namespace IdempotentAPI.IntegrationTests.Infrastructure
                         .UseSetting("Caching", "MemoryCache")
                         .UseSetting("DALock", "None"));
             TestServerClient3 = host3.CreateClient();
+            
+            var hostRedis1 = new WebApplicationFactory<TestWebAPIs1.Program>()
+                .WithWebHostBuilder(builder =>
+                    builder
+                        .UseSetting("Caching", "FusionCache")
+                        .UseSetting("DALock", "MadelsonDistLock"));
+            TestServerClientRedis1 = hostRedis1.CreateClient();
+
+            var hostRedis2 = new WebApplicationFactory<TestWebAPIs2.Program>()
+                .WithWebHostBuilder(builder =>
+                    builder
+                        .UseSetting("Caching", "FusionCache")
+                        .UseSetting("DALock", "MadelsonDistLock"));
+            TestServerClientRedis2 = hostRedis2.CreateClient();
         }
 
         public void Dispose()

--- a/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
+++ b/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
@@ -1,5 +1,7 @@
 ﻿using System.Net;
 using Microsoft.AspNetCore.Mvc.Testing;
+using StackExchange.Redis;
+
 namespace IdempotentAPI.IntegrationTests.Infrastructure
 {
     public class Fixture : IDisposable
@@ -58,20 +60,28 @@ namespace IdempotentAPI.IntegrationTests.Infrastructure
                         .UseSetting("Caching", "MemoryCache")
                         .UseSetting("DALock", "None"));
             TestServerClient3 = host3.CreateClient();
-            
-            var hostRedis1 = new WebApplicationFactory<TestWebAPIs1.Program>()
-                .WithWebHostBuilder(builder =>
-                    builder
-                        .UseSetting("Caching", "FusionCache")
-                        .UseSetting("DALock", "MadelsonDistLock"));
-            TestServerClientRedis1 = hostRedis1.CreateClient();
 
-            var hostRedis2 = new WebApplicationFactory<TestWebAPIs2.Program>()
-                .WithWebHostBuilder(builder =>
-                    builder
-                        .UseSetting("Caching", "FusionCache")
-                        .UseSetting("DALock", "MadelsonDistLock"));
-            TestServerClientRedis2 = hostRedis2.CreateClient();
+            try
+            {
+                var hostRedis1 = new WebApplicationFactory<TestWebAPIs1.Program>()
+                    .WithWebHostBuilder(builder =>
+                        builder
+                            .UseSetting("Caching", "FusionCache")
+                            .UseSetting("DALock", "MadelsonDistLock"));
+                TestServerClientRedis1 = hostRedis1.CreateClient();
+
+                var hostRedis2 = new WebApplicationFactory<TestWebAPIs2.Program>()
+                    .WithWebHostBuilder(builder =>
+                        builder
+                            .UseSetting("Caching", "FusionCache")
+                            .UseSetting("DALock", "MadelsonDistLock"));
+                TestServerClientRedis2 = hostRedis2.CreateClient();
+            }
+            catch (RedisConnectionException redisConnectionException)
+            {
+                Console.WriteLine(
+                    $"Redis not running, test hosts not initialized, Exception: {redisConnectionException}");
+            }
         }
 
         public void Dispose()

--- a/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
+++ b/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-
+using Microsoft.AspNetCore.Mvc.Testing;
 namespace IdempotentAPI.IntegrationTests.Infrastructure
 {
     public class Fixture : IDisposable
@@ -8,6 +8,10 @@ namespace IdempotentAPI.IntegrationTests.Infrastructure
         public HttpClient Client2 { get; }
         public HttpClient Client3 { get; }
 
+        public HttpClient TestServerClient1 { get; }
+        public HttpClient TestServerClient2 { get; }
+        public HttpClient TestServerClient3 { get; }
+        
         public Fixture()
         {
             var defaultHttpClientHandler = new HttpClientHandler
@@ -30,6 +34,27 @@ namespace IdempotentAPI.IntegrationTests.Infrastructure
             {
                 BaseAddress = new Uri("http://localhost:5261/"),
             };
+            
+            var host1 = new WebApplicationFactory<TestWebAPIs1.Program>()
+                .WithWebHostBuilder(builder =>
+                    builder
+                        .UseSetting("Caching", "MemoryCache")
+                        .UseSetting("DALock", "None"));
+            TestServerClient1 = host1.CreateClient();
+
+            var host2 = new WebApplicationFactory<TestWebAPIs2.Program>()
+                .WithWebHostBuilder(builder =>
+                    builder
+                        .UseSetting("Caching", "MemoryCache")
+                        .UseSetting("DALock", "None"));
+            TestServerClient2 = host2.CreateClient();
+
+            var host3 = new WebApplicationFactory<Program>()
+                .WithWebHostBuilder(builder =>
+                    builder
+                        .UseSetting("Caching", "MemoryCache")
+                        .UseSetting("DALock", "None"));
+            TestServerClient3 = host3.CreateClient();
         }
 
         public void Dispose()
@@ -37,6 +62,10 @@ namespace IdempotentAPI.IntegrationTests.Infrastructure
             Client1.Dispose();
             Client2.Dispose();
             Client3.Dispose();
+            
+            TestServerClient1.Dispose();
+            TestServerClient2.Dispose();
+            TestServerClient3.Dispose();
         }
     }
 }

--- a/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
+++ b/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
@@ -1,24 +1,32 @@
-﻿namespace IdempotentAPI.IntegrationTests.Infrastructure
+﻿using System.Net;
+
+namespace IdempotentAPI.IntegrationTests.Infrastructure
 {
     public class Fixture : IDisposable
     {
-        public HttpClient Client1 { get; init; }
-        public HttpClient Client2 { get; init; }
-        public HttpClient Client3 { get; init; }
+        public HttpClient Client1 { get; }
+        public HttpClient Client2 { get; }
+        public HttpClient Client3 { get; }
 
         public Fixture()
         {
-            Client1 = new HttpClient()
+            var defaultHttpClientHandler = new HttpClientHandler
+            {
+                // Disable usage of proxy
+                Proxy = new WebProxy(HttpClient.DefaultProxy.GetProxy(new Uri("http://localhost")), true)
+            };
+            
+            Client1 = new HttpClient(defaultHttpClientHandler)
             {
                 BaseAddress = new Uri("http://localhost:5259/"),
             };
 
-            Client2 = new HttpClient()
+            Client2 = new HttpClient(defaultHttpClientHandler)
             {
                 BaseAddress = new Uri("http://localhost:5260/"),
             };
             
-            Client3 = new HttpClient()
+            Client3 = new HttpClient(defaultHttpClientHandler)
             {
                 BaseAddress = new Uri("http://localhost:5261/"),
             };
@@ -26,8 +34,8 @@
 
         public void Dispose()
         {
-            Client1?.Dispose();
-            Client2?.Dispose();
+            Client1.Dispose();
+            Client2.Dispose();
             Client3.Dispose();
         }
     }

--- a/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
+++ b/tests/IdempotentAPI.IntegrationTests/Infrastructure/Fixture.cs
@@ -4,6 +4,7 @@
     {
         public HttpClient Client1 { get; init; }
         public HttpClient Client2 { get; init; }
+        public HttpClient Client3 { get; init; }
 
         public Fixture()
         {
@@ -16,12 +17,18 @@
             {
                 BaseAddress = new Uri("http://localhost:5260/"),
             };
+            
+            Client3 = new HttpClient()
+            {
+                BaseAddress = new Uri("http://localhost:5261/"),
+            };
         }
 
         public void Dispose()
         {
             Client1?.Dispose();
             Client2?.Dispose();
+            Client3.Dispose();
         }
     }
 }

--- a/tests/IdempotentAPI.IntegrationTests/SingleApiTests.cs
+++ b/tests/IdempotentAPI.IntegrationTests/SingleApiTests.cs
@@ -30,7 +30,7 @@ public class SingleApiTests
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(2)]
-    public async Task PostRequestsConcurrent_OnCSameApi_WithErrorResponse_ShouldReturnTheErrorAndA409Response(int httpClientIndex)
+    public async Task PostRequestsConcurrent_OnSameApi_WithErrorResponse_ShouldReturnTheErrorAndA409Response(int httpClientIndex)
     {
         // Arrange
         var guid = Guid.NewGuid().ToString();

--- a/tests/IdempotentAPI.IntegrationTests/SingleApiTests.cs
+++ b/tests/IdempotentAPI.IntegrationTests/SingleApiTests.cs
@@ -21,10 +21,15 @@ public class SingleApiTests
         _testOutputHelper = testOutputHelper;
         _httpClients = new[]
             {
-                fixture.Client1,
-                fixture.Client2,
-                fixture.Client3
+                fixture.TestServerClient1,
+                fixture.TestServerClient2,
+                fixture.TestServerClient3
             };
+
+        foreach (var httpClient in _httpClients)
+        {
+            httpClient.DefaultRequestHeaders.Clear();
+        }
     }
 
     [Theory]
@@ -72,10 +77,14 @@ public class SingleApiTests
         // Assert
         var content1 = await response1.Content.ReadAsStringAsync();
         var content2 = await response2.Content.ReadAsStringAsync();
+        _testOutputHelper.WriteLine($"content1: {Environment.NewLine}{content1}");
+        _testOutputHelper.WriteLine($"content2: {Environment.NewLine}{content2}");
 
         response1.StatusCode.Should().Be(HttpStatusCode.OK, content1);
         response2.StatusCode.Should().Be(HttpStatusCode.OK, content2);
 
+        content1.Should().NotBeNull();
+        content1.Should().NotBe("null");
         content1.Should().Be(content2);
     }
     
@@ -99,6 +108,8 @@ public class SingleApiTests
         // Assert
         var content1 = await response1.Content.ReadAsStringAsync();
         var content2 = await response2.Content.ReadAsStringAsync();
+        _testOutputHelper.WriteLine($"content1: {Environment.NewLine}{content1}");
+        _testOutputHelper.WriteLine($"content2: {Environment.NewLine}{content2}");
 
         response1.StatusCode.Should().Be(expectedhttpStatusCode, content1);
         response2.StatusCode.Should().Be(expectedhttpStatusCode, content2);
@@ -129,6 +140,9 @@ public class SingleApiTests
 
         response1.StatusCode.Should().Be(expectedhttpStatusCode, content1);
         response2.StatusCode.Should().Be(expectedhttpStatusCode, content2);
+        
+        content1.Should().Be(string.Empty);
+        content2.Should().Be(string.Empty);
     }
     
     [Theory]

--- a/tests/IdempotentAPI.IntegrationTests/SingleApiTests.cs
+++ b/tests/IdempotentAPI.IntegrationTests/SingleApiTests.cs
@@ -65,11 +65,37 @@ public class SingleApiTests
         var response2 = await _httpClients[httpClientIndex].PostAsync("v6/TestingIdempotentAPI/test", null);
 
         // Assert
-        response1.StatusCode.Should().Be(HttpStatusCode.OK);
-        response2.StatusCode.Should().Be(HttpStatusCode.OK);
-
         var content1 = await response1.Content.ReadAsStringAsync();
         var content2 = await response2.Content.ReadAsStringAsync();
+
+        response1.StatusCode.Should().Be(HttpStatusCode.OK, content1);
+        response2.StatusCode.Should().Be(HttpStatusCode.OK, content2);
+
+        content1.Should().Be(content2);
+    }
+    
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task PostTestObject_ShouldReturnCachedResponse(int httpClientIndex)
+    {
+        // Arrange
+        var guid = Guid.NewGuid().ToString();
+
+        _httpClients[httpClientIndex].DefaultRequestHeaders.Add("IdempotencyKey", guid);
+
+        // Act
+        var response1 = await _httpClients[httpClientIndex].PostAsync("v6/TestingIdempotentAPI/testobject", null);
+        var response2 = await _httpClients[httpClientIndex].PostAsync("v6/TestingIdempotentAPI/testobject", null);
+
+        // Assert
+        var content1 = await response1.Content.ReadAsStringAsync();
+        var content2 = await response2.Content.ReadAsStringAsync();
+
+        response1.StatusCode.Should().Be(HttpStatusCode.OK, content1);
+        response2.StatusCode.Should().Be(HttpStatusCode.OK, content2);
+
         content1.Should().Be(content2);
     }
 }

--- a/tests/IdempotentAPI.IntegrationTests/SingleApiTests.cs
+++ b/tests/IdempotentAPI.IntegrationTests/SingleApiTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using FluentAssertions;
+using IdempotentAPI.IntegrationTests.Infrastructure;
+using Xunit;
+
+namespace IdempotentAPI.IntegrationTests;
+
+/// <summary>
+/// Used for testing a single API
+/// NOTE: The API project needs to be running prior to running this test
+/// </summary>
+
+[Collection(nameof(CollectionFixture))]
+public class SingleApiTests
+{
+    private readonly HttpClient[] _httpClients;
+
+    public SingleApiTests(Fixture fixture)
+    {
+        _httpClients = new[]
+        {
+            fixture.Client1,
+            fixture.Client2,
+            fixture.Client3
+        }
+        ;
+    }
+    
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task PostRequestsConcurrent_OnCSameApi_WithErrorResponse_ShouldReturnTheErrorAndA409Response(int httpClientIndex)
+    {
+        // Arrange
+        var guid = Guid.NewGuid().ToString();
+
+        _httpClients[httpClientIndex].DefaultRequestHeaders.Add("IdempotencyKey", guid);
+
+        // Act
+        var httpPostTask1 = _httpClients[httpClientIndex].PostAsync("v6/TestingIdempotentAPI/customNotAcceptable406?delaySeconds=5", null);
+        var httpPostTask2 = _httpClients[httpClientIndex].PostAsync("v6/TestingIdempotentAPI/customNotAcceptable406?delaySeconds=5", null);
+
+        await Task.WhenAll(httpPostTask1, httpPostTask2);
+
+        // Assert
+        var resultStatusCodes = new List<HttpStatusCode>() { httpPostTask1.Result.StatusCode, httpPostTask2.Result.StatusCode };
+        resultStatusCodes.Should().Contain(HttpStatusCode.NotAcceptable);
+        resultStatusCodes.Should().Contain(HttpStatusCode.Conflict);
+    }
+    
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task PostTest_ShouldReturnCachedResponse(int httpClientIndex)
+    {
+        // Arrange
+        var guid = Guid.NewGuid().ToString();
+
+        _httpClients[httpClientIndex].DefaultRequestHeaders.Add("IdempotencyKey", guid);
+
+        // Act
+        var response1 = await _httpClients[httpClientIndex].PostAsync("v6/TestingIdempotentAPI/test", null);
+        var response2 = await _httpClients[httpClientIndex].PostAsync("v6/TestingIdempotentAPI/test", null);
+
+        // Assert
+        response1.StatusCode.Should().Be(HttpStatusCode.OK);
+        response2.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content1 = await response1.Content.ReadAsStringAsync();
+        var content2 = await response2.Content.ReadAsStringAsync();
+        content1.Should().Be(content2);
+    }
+}

--- a/tests/IdempotentAPI.IntegrationTests/TestWebAPIsConcurrentTests.cs
+++ b/tests/IdempotentAPI.IntegrationTests/TestWebAPIsConcurrentTests.cs
@@ -20,8 +20,11 @@ namespace IdempotentAPI.IntegrationTests
 
         public TestWebAPIsConcurrentTests(Fixture fixture)
         {
-            _httpClientForInstance1 = fixture.Client1;
-            _httpClientForInstance2 = fixture.Client2;
+            _httpClientForInstance1 = fixture.TestServerClientRedis1;
+            _httpClientForInstance2 = fixture.TestServerClientRedis2;
+            
+            _httpClientForInstance1.DefaultRequestHeaders.Clear();
+            _httpClientForInstance2.DefaultRequestHeaders.Clear();
         }
 
         [Fact]

--- a/tests/IdempotentAPI.TestWebAPIs1/Controllers/TestingIdempotentAPIController.cs
+++ b/tests/IdempotentAPI.TestWebAPIs1/Controllers/TestingIdempotentAPIController.cs
@@ -76,7 +76,7 @@ namespace IdempotentAPI.TestWebAPIs1.Controllers
                 StatusCode = StatusCodes.Status406NotAcceptable,
                 Errors = new[]{
                     message
-                },
+                }
             })
             {
                 StatusCode = StatusCodes.Status406NotAcceptable,

--- a/tests/IdempotentAPI.TestWebAPIs1/Controllers/TestingIdempotentAPIController.cs
+++ b/tests/IdempotentAPI.TestWebAPIs1/Controllers/TestingIdempotentAPIController.cs
@@ -24,7 +24,7 @@ namespace IdempotentAPI.TestWebAPIs1.Controllers
         }
 
         [HttpPost("test")]
-        public ActionResult Test()
+        public ActionResult Test([FromHeader(Name = "IdempotencyKey")] string idempotencyKey)
         {
             return Ok(new ResponseDTOs());
         }
@@ -37,7 +37,8 @@ namespace IdempotentAPI.TestWebAPIs1.Controllers
 
 
         [HttpPost("testobjectWithHttpError")]
-        public async Task<ActionResult> TestObjectWithHttpErrorAsync(int delaySeconds, int httpErrorCode)
+        public async Task<ActionResult> TestObjectWithHttpErrorAsync(
+            [FromHeader(Name = "IdempotencyKey")] string idempotencyKey, int delaySeconds, int httpErrorCode)
         {
             await Task.Delay(delaySeconds * 1000);
 
@@ -46,26 +47,21 @@ namespace IdempotentAPI.TestWebAPIs1.Controllers
 
 
         [HttpPost("testobjectWithException")]
-        public async Task<ActionResult> TestObjectWithExceptionAsync(int delaySeconds)
+        public async Task<ActionResult> TestObjectWithExceptionAsync(
+            [FromHeader(Name = "IdempotencyKey")] string idempotencyKey, int delaySeconds)
         {
             await Task.Delay(delaySeconds * 1000);
 
             throw new Exception("Something when wrong!");
         }
 
-
         [HttpPost("customNotAcceptable406")]
-        public async Task<ActionResult> TestCustomNotAcceptable406Async(int delaySeconds)
+        public async Task<ActionResult> TestCustomNotAcceptable406Async(
+            [FromHeader(Name = "IdempotencyKey")] string idempotencyKey, int delaySeconds)
         {
-            if (!Request.Headers.TryGetValue("IdempotencyKey", out StringValues idempotencyKeys))
-            {
-                throw new ArgumentNullException("IdempotencyKey");
-            }
-
-            var idempotencyKey = idempotencyKeys.FirstOrDefault();
             if (idempotencyKey is null)
             {
-                throw new ArgumentNullException("IdempotencyKey");
+                throw new ArgumentNullException(nameof(idempotencyKey));
             }
 
             _logger.LogInformation($"Host: {Request.Host.Value} | IdempotencyKey: {idempotencyKey}");

--- a/tests/IdempotentAPI.TestWebAPIs1/IdempotentAPI.TestWebAPIs1.csproj
+++ b/tests/IdempotentAPI.TestWebAPIs1/IdempotentAPI.TestWebAPIs1.csproj
@@ -10,6 +10,7 @@
 		<PackageReference Include="DistributedLock.Redis" Version="1.0.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.9" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/IdempotentAPI.TestWebAPIs1/Properties/launchSettings.json
+++ b/tests/IdempotentAPI.TestWebAPIs1/Properties/launchSettings.json
@@ -28,6 +28,18 @@
         "Caching": "FusionCache",
         "DALock": "MadelsonDistLock"
       }
+    },
+    "IdempotentAPI.TestWebAPIs1 memory cache": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "launchBrowser": false,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "https://localhost:7029;http://localhost:5259",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "Caching": "MemoryCache",
+        "DALock": "None"
+      }
     }
   }
 }

--- a/tests/IdempotentAPI.TestWebAPIs1/Startup.cs
+++ b/tests/IdempotentAPI.TestWebAPIs1/Startup.cs
@@ -7,6 +7,7 @@ using IdempotentAPI.Extensions.DependencyInjection;
 using IdempotentAPI.TestWebAPIs1.Extensions;
 using Medallion.Threading;
 using Medallion.Threading.Redis;
+using Microsoft.OpenApi.Models;
 using StackExchange.Redis;
 
 namespace IdempotentAPI.TestWebAPIs1
@@ -36,8 +37,10 @@ namespace IdempotentAPI.TestWebAPIs1
             // Register the IdempotentAPI Core services.
             services.AddIdempotentAPI();
 
+            services.AddSwaggerGen(x =>
+                x.SwaggerDoc("v6", new OpenApiInfo { Title = "IdempotentAPI.TestWebAPIs1 - Swagger", Version = "v6" }));
+            
             services.AddControllers();
-
 
             // Register the Caching Method:
             var caching = Configuration.GetValue<string>("Caching");
@@ -83,6 +86,9 @@ namespace IdempotentAPI.TestWebAPIs1
                     services.AddSingleton<IDistributedLockProvider>(_ => new RedisDistributedSynchronizationProvider(redicConnection.GetDatabase()));
                     services.AddMadelsonDistributedAccessLock();
                     break;
+                case "None":
+                    Console.WriteLine("No distributed cache will be used.");
+                    break;
                 default:
                     Console.WriteLine($"Distributed Access Lock Method '{distributedAccessLock}' is not recognized. Options: RedLockNet, MadelsonDistLock.");
                     Environment.Exit(0);
@@ -94,20 +100,19 @@ namespace IdempotentAPI.TestWebAPIs1
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            //if (env.IsDevelopment())
-            //{
-            //    app.UseDeveloperExceptionPage();
-            //}
-
-            //app.UseHttpsRedirection();
-
             app.UseRouting();
-
-            //app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+            });
+            
+            app.UseSwagger();
+            app.UseSwaggerUI(c =>
+            {
+                c.DocumentTitle = "IdempotentAPI.TestWebAPIs1 - Swagger";
+                c.RoutePrefix = string.Empty;
+                c.SwaggerEndpoint("./swagger/v6/swagger.json", "v1");
             });
         }
     }

--- a/tests/IdempotentAPI.TestWebAPIs2/Controllers/TestingIdempotentAPIController.cs
+++ b/tests/IdempotentAPI.TestWebAPIs2/Controllers/TestingIdempotentAPIController.cs
@@ -24,20 +24,21 @@ namespace IdempotentAPI.TestWebAPIs2.Controllers
         }
 
         [HttpPost("test")]
-        public ActionResult Test()
+        public ActionResult Test([FromHeader(Name = "IdempotencyKey")] string idempotencyKey)
         {
             return Ok(new ResponseDTOs());
         }
 
         [HttpPost("testobject")]
-        public ResponseDTOs TestObject()
+        public ResponseDTOs TestObject([FromHeader(Name = "IdempotencyKey")] string idempotencyKey)
         {
             return new ResponseDTOs();
         }
 
 
         [HttpPost("testobjectWithHttpError")]
-        public async Task<ActionResult> TestObjectWithHttpErrorAsync(int delaySeconds, int httpErrorCode)
+        public async Task<ActionResult> TestObjectWithHttpErrorAsync(
+            [FromHeader(Name = "IdempotencyKey")] string idempotencyKey, int delaySeconds, int httpErrorCode)
         {
             await Task.Delay(delaySeconds * 1000);
 
@@ -46,7 +47,8 @@ namespace IdempotentAPI.TestWebAPIs2.Controllers
 
 
         [HttpPost("testobjectWithException")]
-        public async Task<ActionResult> TestObjectWithExceptionAsync(int delaySeconds)
+        public async Task<ActionResult> TestObjectWithExceptionAsync(
+            [FromHeader(Name = "IdempotencyKey")] string idempotencyKey, int delaySeconds)
         {
             await Task.Delay(delaySeconds * 1000);
 
@@ -55,17 +57,12 @@ namespace IdempotentAPI.TestWebAPIs2.Controllers
 
 
         [HttpPost("customNotAcceptable406")]
-        public async Task<ActionResult> TestCustomNotAcceptable406Async(int delaySeconds)
+        public async Task<ActionResult> TestCustomNotAcceptable406Async(
+            [FromHeader(Name = "IdempotencyKey")] string idempotencyKey, int delaySeconds)
         {
-            if (!Request.Headers.TryGetValue("IdempotencyKey", out StringValues idempotencyKeys))
-            {
-                throw new ArgumentNullException("IdempotencyKey");
-            }
-
-            var idempotencyKey = idempotencyKeys.FirstOrDefault();
             if (idempotencyKey is null)
             {
-                throw new ArgumentNullException("IdempotencyKey");
+                throw new ArgumentNullException(nameof(idempotencyKey));
             }
 
             _logger.LogInformation($"Host: {Request.Host.Value} | IdempotencyKey: {idempotencyKey}");

--- a/tests/IdempotentAPI.TestWebAPIs2/IdempotentAPI.TestWebAPIs2.csproj
+++ b/tests/IdempotentAPI.TestWebAPIs2/IdempotentAPI.TestWebAPIs2.csproj
@@ -10,8 +10,8 @@
 		<PackageReference Include="DistributedLock.Redis" Version="1.0.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.9" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 	</ItemGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\IdempotentAPI.Cache.DistributedCache\IdempotentAPI.Cache.DistributedCache.csproj" />
 		<ProjectReference Include="..\..\src\IdempotentAPI.Cache.FusionCache\IdempotentAPI.Cache.FusionCache.csproj" />

--- a/tests/IdempotentAPI.TestWebAPIs2/Properties/launchSettings.json
+++ b/tests/IdempotentAPI.TestWebAPIs2/Properties/launchSettings.json
@@ -28,6 +28,18 @@
         "Caching": "FusionCache",
         "DALock": "MadelsonDistLock"
       }
+    },
+    "IdempotentAPI.TestWebAPIs2 memory cache": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "launchBrowser": false,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "https://localhost:7030;http://localhost:5260",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "Caching": "MemoryCache",
+        "DALock": "None"
+      }
     }
   }
 }

--- a/tests/IdempotentAPI.TestWebAPIs3/DTOs/ErrorModel.cs
+++ b/tests/IdempotentAPI.TestWebAPIs3/DTOs/ErrorModel.cs
@@ -1,0 +1,11 @@
+﻿using System.Net;
+
+namespace IdempotentAPI.TestWebAPIs1.DTOs
+{
+    public class ErrorModel
+    {
+        public HttpStatusCode Title { get; set; }
+        public int StatusCode { get; set; }
+        public string[]? Errors { get; set; }
+    }
+}

--- a/tests/IdempotentAPI.TestWebAPIs3/DTOs/ResponseDTOs.cs
+++ b/tests/IdempotentAPI.TestWebAPIs3/DTOs/ResponseDTOs.cs
@@ -1,0 +1,9 @@
+﻿namespace IdempotentAPI.TestWebAPIs3.DTOs
+{
+    [Serializable]
+    public class ResponseDTOs
+    {
+        public Guid Idempotency { get; set; } = Guid.NewGuid();
+        public DateTime CreatedOn { get; set; } = DateTime.Now;
+    }
+}

--- a/tests/IdempotentAPI.TestWebAPIs3/IdempotentAPI.TestWebAPIs3.csproj
+++ b/tests/IdempotentAPI.TestWebAPIs3/IdempotentAPI.TestWebAPIs3.csproj
@@ -14,5 +14,9 @@
     <ProjectReference Include="..\..\src\IdempotentAPI.Cache.DistributedCache\IdempotentAPI.Cache.DistributedCache.csproj" />
     <ProjectReference Include="..\..\src\IdempotentAPI\IdempotentAPI.csproj" />
   </ItemGroup>
-
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>IdempotentAPI.IntegrationTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/tests/IdempotentAPI.TestWebAPIs3/IdempotentAPI.TestWebAPIs3.csproj
+++ b/tests/IdempotentAPI.TestWebAPIs3/IdempotentAPI.TestWebAPIs3.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\IdempotentAPI.Cache.DistributedCache\IdempotentAPI.Cache.DistributedCache.csproj" />
+    <ProjectReference Include="..\..\src\IdempotentAPI\IdempotentAPI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/IdempotentAPI.TestWebAPIs3/IdempotentEndpointFilter.cs
+++ b/tests/IdempotentAPI.TestWebAPIs3/IdempotentEndpointFilter.cs
@@ -1,0 +1,46 @@
+﻿using IdempotentAPI.Filters;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace IdempotentAPI.TestWebAPIs3;
+
+public class IdempotentEndpointFilter : IEndpointFilter
+{
+    private readonly IdempotencyAttributeFilter _idempotencyAttributeFilter;
+
+    public IdempotentEndpointFilter(IdempotencyAttributeFilter idempotencyAttributeFilter)
+    {
+        _idempotencyAttributeFilter = idempotencyAttributeFilter;
+    }
+    
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var actionContext = new ActionContext(context.HttpContext, new RouteData(), new ActionDescriptor());
+        var filters = new List<IFilterMetadata>();
+        var actionArguments = new Dictionary<string, object?>();
+        var actionExecutingContext = new ActionExecutingContext(actionContext, filters, actionArguments, null!);
+        _idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext);
+
+        var actionExecutedContext = new ActionExecutedContext(actionContext, filters, null!);
+        _idempotencyAttributeFilter.OnActionExecuted(actionExecutedContext);
+
+        ObjectResult apiResult;
+        if (actionExecutingContext.Result == null)
+        {
+            apiResult = new ObjectResult(await next(context));
+        }
+        else
+        {
+            apiResult = (ObjectResult)actionExecutingContext.Result;
+        }
+        
+        var resultExecutingContext = new ResultExecutingContext(actionContext, filters, apiResult, null!);
+        _idempotencyAttributeFilter.OnResultExecuting(resultExecutingContext);
+        
+        var resultExecutedContext = new ResultExecutedContext(actionContext, filters, apiResult, null!);
+        _idempotencyAttributeFilter.OnResultExecuted(resultExecutedContext);
+
+        return apiResult.Value;
+    }
+}

--- a/tests/IdempotentAPI.TestWebAPIs3/IdempotentEndpointFilter.cs
+++ b/tests/IdempotentAPI.TestWebAPIs3/IdempotentEndpointFilter.cs
@@ -36,10 +36,14 @@ public class IdempotentEndpointFilter : IEndpointFilter
             {
                 var realCallResult = await next(context);
 
-                object? value = null;
-                if (realCallResult is IValueHttpResult result)
+                object? value = string.Empty;
+                if (realCallResult is not IResult)
                 {
-                    value = result.Value;
+                    value = realCallResult;
+                }
+                else if (realCallResult is IValueHttpResult valueHttpResult)
+                {
+                    value = valueHttpResult.Value;
                 }
                 
                 objectResult = new ObjectResult(value);
@@ -52,7 +56,7 @@ public class IdempotentEndpointFilter : IEndpointFilter
             }
             else
             {
-                object? value = null;
+                object? value = string.Empty;
                 if (actionExecutingContext.Result is ObjectResult valueHttpResult)
                 {
                     value = valueHttpResult.Value;

--- a/tests/IdempotentAPI.TestWebAPIs3/IdempotentEndpointFilter.cs
+++ b/tests/IdempotentAPI.TestWebAPIs3/IdempotentEndpointFilter.cs
@@ -1,4 +1,5 @@
-﻿using IdempotentAPI.Filters;
+﻿using System.Net;
+using IdempotentAPI.Filters;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -8,39 +9,80 @@ namespace IdempotentAPI.TestWebAPIs3;
 public class IdempotentEndpointFilter : IEndpointFilter
 {
     private readonly IdempotencyAttributeFilter _idempotencyAttributeFilter;
+    private readonly ILogger<IdempotentEndpointFilter> _logger;
 
-    public IdempotentEndpointFilter(IdempotencyAttributeFilter idempotencyAttributeFilter)
+    public IdempotentEndpointFilter(IdempotencyAttributeFilter idempotencyAttributeFilter, ILogger<IdempotentEndpointFilter> logger)
     {
         _idempotencyAttributeFilter = idempotencyAttributeFilter;
+        _logger = logger;
     }
     
     public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
     {
-        var actionContext = new ActionContext(context.HttpContext, new RouteData(), new ActionDescriptor());
-        var filters = new List<IFilterMetadata>();
-        var actionArguments = new Dictionary<string, object?>();
-        var actionExecutingContext = new ActionExecutingContext(actionContext, filters, actionArguments, null!);
-        _idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext);
-
-        var actionExecutedContext = new ActionExecutedContext(actionContext, filters, null!);
-        _idempotencyAttributeFilter.OnActionExecuted(actionExecutedContext);
-
-        ObjectResult apiResult;
-        if (actionExecutingContext.Result == null)
+        try
         {
-            apiResult = new ObjectResult(await next(context));
-        }
-        else
-        {
-            apiResult = (ObjectResult)actionExecutingContext.Result;
-        }
-        
-        var resultExecutingContext = new ResultExecutingContext(actionContext, filters, apiResult, null!);
-        _idempotencyAttributeFilter.OnResultExecuting(resultExecutingContext);
-        
-        var resultExecutedContext = new ResultExecutedContext(actionContext, filters, apiResult, null!);
-        _idempotencyAttributeFilter.OnResultExecuted(resultExecutedContext);
+            var actionContext = new ActionContext(context.HttpContext, new RouteData(), new ActionDescriptor());
+            var filters = new List<IFilterMetadata>();
+            var actionArguments = new Dictionary<string, object?>();
+            var actionExecutingContext = new ActionExecutingContext(actionContext, filters, actionArguments, null!);
+            _idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext);
 
-        return apiResult.Value;
+            var actionExecutedContext = new ActionExecutedContext(actionContext, filters, null!);
+            _idempotencyAttributeFilter.OnActionExecuted(actionExecutedContext);
+
+            ObjectResult objectResult;
+            if (actionExecutingContext.Result == null)
+            {
+                var realCallResult = await next(context);
+
+                if (realCallResult is IValueHttpResult result)
+                {
+                    realCallResult = result.Value;
+                }
+                
+                objectResult = new ObjectResult(realCallResult);
+
+                if (realCallResult is IStatusCodeHttpResult statusCodeHttpResult)
+                {
+                    objectResult.StatusCode = statusCodeHttpResult.StatusCode;
+                }
+            }
+            else
+            {
+                objectResult = (ObjectResult)actionExecutingContext.Result;
+                context.HttpContext.Response.StatusCode = objectResult.StatusCode!.Value;
+            }
+
+            var resultExecutingContext = new ResultExecutingContext(actionContext, filters, objectResult, null!);
+            _idempotencyAttributeFilter.OnResultExecuting(resultExecutingContext);
+
+            var resultExecutedContext = new ResultExecutedContext(actionContext, filters, objectResult, null!);
+            _idempotencyAttributeFilter.OnResultExecuted(resultExecutedContext);
+
+            return objectResult.Value;
+        }
+        catch (ArgumentNullException argumentNullException)
+        {
+            if (argumentNullException.ParamName == "IdempotencyKey")
+            {
+                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+            }
+            else
+            {
+                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            }
+            
+            _logger.LogError(argumentNullException, "Idempotency error");
+
+            return argumentNullException.ToString();
+        }
+        catch (Exception exception)
+        {
+            context.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            
+            _logger.LogError(exception, "Idempotency error");
+            
+            return exception.ToString();
+        }
     }
 }

--- a/tests/IdempotentAPI.TestWebAPIs3/Program.cs
+++ b/tests/IdempotentAPI.TestWebAPIs3/Program.cs
@@ -1,0 +1,39 @@
+using IdempotentAPI.Cache.DistributedCache.Extensions.DependencyInjection;
+using IdempotentAPI.Extensions.DependencyInjection;
+using IdempotentAPI.Filters;
+using IdempotentAPI.TestWebAPIs3;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddIdempotentAPI();
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddIdempotentAPIUsingDistributedCache();
+
+builder.Services.AddTransient(serviceProvider =>
+{
+    var idempotentAttribute = new IdempotentAttribute();
+    return (IdempotencyAttributeFilter)idempotentAttribute.CreateInstance(serviceProvider);
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(x =>
+    x.SwaggerDoc("v1", new OpenApiInfo { Title = "IdempotentAPI.TestWebAPIs3 - Swagger", Version = "v1" }));
+
+var app = builder.Build();
+
+app.MapPost("/api/",
+        ([FromHeader] string idempotencyKey
+        ) => new Response { Message = "Hello world", IdempotencyKey = idempotencyKey, Timestamp = DateTime.Now })
+    .AddEndpointFilter<IdempotentEndpointFilter>();
+
+app.UseSwagger();
+app.UseSwaggerUI(c =>
+{
+    c.DocumentTitle = "IdempotentAPI.TestWebAPIs3 - Swagger";
+    c.RoutePrefix = string.Empty;
+    c.SwaggerEndpoint("./swagger/v1/swagger.json", "v1");
+});
+
+app.Run();

--- a/tests/IdempotentAPI.TestWebAPIs3/Program.cs
+++ b/tests/IdempotentAPI.TestWebAPIs3/Program.cs
@@ -1,7 +1,10 @@
+using System.Net;
 using IdempotentAPI.Cache.DistributedCache.Extensions.DependencyInjection;
 using IdempotentAPI.Extensions.DependencyInjection;
 using IdempotentAPI.Filters;
+using IdempotentAPI.TestWebAPIs1.DTOs;
 using IdempotentAPI.TestWebAPIs3;
+using IdempotentAPI.TestWebAPIs3.DTOs;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
 
@@ -13,19 +16,74 @@ builder.Services.AddIdempotentAPIUsingDistributedCache();
 
 builder.Services.AddTransient(serviceProvider =>
 {
-    var idempotentAttribute = new IdempotentAttribute();
+    var idempotentAttribute = new IdempotentAttribute
+    {
+        CacheOnlySuccessResponses = true,
+        DistributedLockTimeoutMilli = 2000
+    };
     return (IdempotencyAttributeFilter)idempotentAttribute.CreateInstance(serviceProvider);
 });
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(x =>
-    x.SwaggerDoc("v1", new OpenApiInfo { Title = "IdempotentAPI.TestWebAPIs3 - Swagger", Version = "v1" }));
+    x.SwaggerDoc("v6", new OpenApiInfo { Title = "IdempotentAPI.TestWebAPIs3 - Swagger", Version = "v6" }));
 
 var app = builder.Build();
 
-app.MapPost("/api/",
-        ([FromHeader] string idempotencyKey
-        ) => new Response { Message = "Hello world", IdempotencyKey = idempotencyKey, Timestamp = DateTime.Now })
+app
+    .MapPost("/v6/TestingIdempotentAPI/test", 
+        ([FromHeader(Name = "IdempotencyKey")] string idempotencyKey) => Results.Ok(new ResponseDTOs()))
+    .AddEndpointFilter<IdempotentEndpointFilter>();
+
+app
+    .MapPost("/v6/TestingIdempotentAPI/testobject", 
+        ([FromHeader(Name = "IdempotencyKey")] string idempotencyKey) => new ResponseDTOs())
+    .AddEndpointFilter<IdempotentEndpointFilter>();
+
+app
+    .MapPost("/v6/TestingIdempotentAPI/testobjectWithHttpError", 
+        async ([FromHeader(Name = "IdempotencyKey")] string idempotencyKey, int delaySeconds, int httpErrorCode) =>
+        {
+            await Task.Delay(delaySeconds * 1000);
+            return Results.StatusCode(httpErrorCode);
+        })
+    .AddEndpointFilter<IdempotentEndpointFilter>();
+
+app
+    .MapPost("/v6/TestingIdempotentAPI/testobjectWithException", 
+        async ([FromHeader(Name = "IdempotencyKey")] string idempotencyKey, int delaySeconds) =>
+        {
+            await Task.Delay(delaySeconds * 1000);
+            throw new Exception("Something when wrong!");
+        })
+    .AddEndpointFilter<IdempotentEndpointFilter>();
+
+app
+    .MapPost("/v6/TestingIdempotentAPI/customNotAcceptable406", 
+        async ([FromHeader(Name = "IdempotencyKey")] string idempotencyKey, int delaySeconds) =>
+        {
+            if (idempotencyKey is null)
+            {
+                throw new ArgumentNullException(nameof(idempotencyKey));
+            }
+
+            //TODO: Add support for logging
+            //_logger.LogInformation($"Host: {Request.Host.Value} | IdempotencyKey: {idempotencyKey}");
+
+            await Task.Delay(delaySeconds * 1000);
+
+            string message = $"Not Acceptable! {DateTime.Now:s}";
+
+            return Results.Json(new ErrorModel
+            {
+                Title = HttpStatusCode.NotAcceptable,
+                StatusCode = StatusCodes.Status406NotAcceptable,
+                Errors = new[]
+                {
+                    message
+                }
+            }, statusCode: StatusCodes.Status406NotAcceptable);
+        })
     .AddEndpointFilter<IdempotentEndpointFilter>();
 
 app.UseSwagger();
@@ -33,7 +91,7 @@ app.UseSwaggerUI(c =>
 {
     c.DocumentTitle = "IdempotentAPI.TestWebAPIs3 - Swagger";
     c.RoutePrefix = string.Empty;
-    c.SwaggerEndpoint("./swagger/v1/swagger.json", "v1");
+    c.SwaggerEndpoint("./swagger/v6/swagger.json", "v6");
 });
 
 app.Run();

--- a/tests/IdempotentAPI.TestWebAPIs3/Properties/launchSettings.json
+++ b/tests/IdempotentAPI.TestWebAPIs3/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:23211",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:23211",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tests/IdempotentAPI.TestWebAPIs3/Properties/launchSettings.json
+++ b/tests/IdempotentAPI.TestWebAPIs3/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:23211",
+      "applicationUrl": "http://localhost:5261",
       "sslPort": 0
     }
   },
@@ -12,7 +12,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:23211",
+      "applicationUrl": "http://localhost:5261",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/tests/IdempotentAPI.TestWebAPIs3/Response.cs
+++ b/tests/IdempotentAPI.TestWebAPIs3/Response.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace IdempotentAPI.TestWebAPIs3;
+
+[Serializable]
+public class Response
+{
+    [JsonInclude]
+    public string? Message { get; set; }
+
+    [JsonInclude]
+    public string? IdempotencyKey { get; set; }
+
+    [JsonInclude]
+    public DateTime Timestamp { get; set; }
+}

--- a/tests/IdempotentAPI.TestWebAPIs3/appsettings.Development.json
+++ b/tests/IdempotentAPI.TestWebAPIs3/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tests/IdempotentAPI.TestWebAPIs3/appsettings.json
+++ b/tests/IdempotentAPI.TestWebAPIs3/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
We have a minimal API and we wanted to use this nugget, but it seems MVC action filters isn't supported so we have used EndpointFilters that was added in .NET 7.

To make use of the endpoint filter you just need to add
`    .AddEndpointFilter<IdempotentEndpointFilter>()`

We cannot decorate the action with any attribute so we inject **IdempotencyAttributeFilter**, And **IdempotentEndpointFilter** uses  this injected instance. So we will have same settings for all endpoints with this implementation.

We will continue use this implementation in our application and haven't tested every different combinations of calls yet, but the preliminary testing looks alright.

One way forward for this nuget would be to make an abstraction layer that the endpoint filtering in minimal API can interface with instead of do the magic hackery found in **IdempotentEndpointFilter**

Do anyone have any comments and/or suggestions for our implementation?