### PR TITLE
Fix MinimalApi HttpRequest self-referencing loop when serializing - Issue 65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.2.1] - 2024-02-??
+- Fix for Minimal API: When the special types (such as `HttpRequest`) are used as arguments, a Newtonsoft serialization exception for a self-referencing loop is thrown. The primary exception information is the following. Thank you to [@hartmark](https://github.com/hartmark) for reporting and investigating this issue ([#65](https://github.com/ikyriak/IdempotentAPI/issues/65)) 🙏.
+    - `Newtonsoft.Json.JsonSerializationException: Self referencing loop detected for property 'ServiceProvider' with type 'Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope'`
+
 ## [2.2.0] - 2023-12-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [2.2.1] - 2024-02-??
+## [2.3.0] - 2024-02-??  - Minimal APIs (IdempotentAPI.MinimalAPI v3.0.0)
+- The `AddIdempotentMinimalAPI(...)` extension is introduced to simplify the  `IdempotentAPI.MinimalAPI` registration with DI improvements by [@hartmark](https://github.com/hartmark).
+    - IMPORTANT: To use the new extensions, the **BREAKING** `IdempotentAPI.MinimalAPI v3.0.0` should be used.
+    - The new extensions register the following services:
+    ```c#
+    public static IServiceCollection AddIdempotentMinimalAPI(this IServiceCollection serviceCollection, IdempotencyOptions idempotencyOptions)
+    {
+        serviceCollection.AddSingleton<IIdempotencyAccessCache, IdempotencyAccessCache>();
+        serviceCollection.AddSingleton<IIdempotencyOptions>(idempotencyOptions);
+        serviceCollection.AddTransient(serviceProvider =>
+        {
+            var distributedCache = serviceProvider.GetRequiredService<IIdempotencyAccessCache>();
+            var logger = serviceProvider.GetRequiredService<ILogger<Idempotency>>();
+            var idempotencyOptions = serviceProvider.GetRequiredService<IIdempotencyOptions>();
+
+            return new Idempotency(
+                distributedCache,
+                logger,
+                idempotencyOptions.ExpiresInMilliseconds,
+                idempotencyOptions.HeaderKeyName,
+                idempotencyOptions.DistributedCacheKeysPrefix,
+                TimeSpan.FromMilliseconds(idempotencyOptions.DistributedLockTimeoutMilli),
+                idempotencyOptions.CacheOnlySuccessResponses,
+                idempotencyOptions.IsIdempotencyOptional);
+        });
+
+        return serviceCollection;
+    }
+    ```
 - Fix for Minimal API: When the special types (such as `HttpRequest`) are used as arguments, a Newtonsoft serialization exception for a self-referencing loop is thrown. The primary exception information is the following. Thank you to [@hartmark](https://github.com/hartmark) for reporting and investigating this issue ([#65](https://github.com/ikyriak/IdempotentAPI/issues/65)) 🙏.
     - `Newtonsoft.Json.JsonSerializationException: Self referencing loop detected for property 'ServiceProvider' with type 'Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope'`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [2.3.0] - 2024-02-??  - Minimal APIs (IdempotentAPI.MinimalAPI v3.0.0)
-- The `AddIdempotentMinimalAPI(...)` extension is introduced to simplify the  `IdempotentAPI.MinimalAPI` registration with DI improvements by [@hartmark](https://github.com/hartmark).
-    - IMPORTANT: To use the new extensions, the **BREAKING** `IdempotentAPI.MinimalAPI v3.0.0` should be used.
+## [2.3.0] - 2024-03-07  - Minimal APIs (IdempotentAPI.MinimalAPI v3.0.0)
+- 🌟 The `AddIdempotentMinimalAPI(...)` extension is introduced to simplify the  `IdempotentAPI.MinimalAPI` registration with DI improvements by [@hartmark](https://github.com/hartmark).
+    - ❗ IMPORTANT: To use the new extensions, the **BREAKING** `IdempotentAPI.MinimalAPI v3.0.0` should be used.
     - The new extensions register the following services:
     ```c#
     public static IServiceCollection AddIdempotentMinimalAPI(this IServiceCollection serviceCollection, IdempotencyOptions idempotencyOptions)
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
         return serviceCollection;
     }
     ```
-- Fix for Minimal API: When the special types (such as `HttpRequest`) are used as arguments, a Newtonsoft serialization exception for a self-referencing loop is thrown. The primary exception information is the following. Thank you to [@hartmark](https://github.com/hartmark) for reporting and investigating this issue ([#65](https://github.com/ikyriak/IdempotentAPI/issues/65)) 🙏.
+- ✅ Fix for Minimal API: When the special types (such as `HttpRequest`) are used as arguments, a Newtonsoft serialization exception for a self-referencing loop is thrown. The primary exception information is the following. Thank you to [@hartmark](https://github.com/hartmark) for reporting and investigating this issue ([#65](https://github.com/ikyriak/IdempotentAPI/issues/65)) 🙏.
     - `Newtonsoft.Json.JsonSerializationException: Self referencing loop detected for property 'ServiceProvider' with type 'Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope'`
 
 ## [2.2.0] - 2023-12-26

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Idempotent API (v2.2.0)
+# Idempotent API (v2.3.0)
 
 
 
@@ -86,7 +86,7 @@ The following figure shows a simplified example of the `IdempotentAPI` library f
 
 
 
-## 📦 Main NuGet Packages (v2.2.0)
+## 📦 Main NuGet Packages
 
 | Package Name                                                 | Description                                                  | Release                                                      |
 | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
@@ -96,7 +96,7 @@ The following figure shows a simplified example of the `IdempotentAPI` library f
 
 
 
-## 📦 Caching NuGet Packages (v2.2.0)
+## 📦 Caching NuGet Packages
 
 | Package Name                                                 | Description                                                  | Release                                                      |
 | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
@@ -106,7 +106,7 @@ The following figure shows a simplified example of the `IdempotentAPI` library f
 
 
 
-## 📦 Distributed Locking NuGet Packages (v2.1.0)
+## 📦 Distributed Locking NuGet Packages
 
 | Package Name                                                 | Description                                                  | Release                                                      |
 | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
@@ -121,13 +121,21 @@ The following figure shows a simplified example of the `IdempotentAPI` library f
 Let's see how we could use the NuGet packages in a Web API project. For more examples and code, you can check the [sample projects](https://github.com/ikyriak/IdempotentAPI/tree/master/samples). The `IdempotentAPI` can be installed via the NuGet UI or the NuGet package manager console:
 
 ```powershell
-PM> Install-Package IdempotentAPI -Version 2.2.0
+PM> Install-Package IdempotentAPI -Version 2.3.0
 ```
 
-and, register the IdempotentAPI Core services:
+and, register the **IdempotentAPI Core services** for either controller-based APIs or minimal APIs.
 
 ```c#
+// For Controller-Based APIs:
 services.AddIdempotentAPI();
+```
+
+OR
+
+```c#
+// For Minimal APIs:
+builder.Services.AddIdempotentMinimalAPI(new IdempotencyOptions());
 ```
 
 
@@ -313,7 +321,7 @@ public IActionResult Post([FromBody] SimpleRequest simpleRequest)
 
 #### Using the IdempotentAPI Endpoint Filter on Minimal APIs
 
-The [IdempotentAPI.MinimalAPI](https://www.nuget.org/packages/IdempotentAPI.MinimalAPI) package should be installed and then add the `IdempotentAPIEndpointFilter` in your endpoints.
+The latest [IdempotentAPI.MinimalAPI](https://www.nuget.org/packages/IdempotentAPI.MinimalAPI) package should be installed and then add the `IdempotentAPIEndpointFilter` in your endpoints.
 
 ```c#
 app.MapPost("/example",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ HTTP defines a set of request [methods](https://developer.mozilla.org/en-US/docs
 
 ### Idempotent Web Consumer
 
-The creation of an `idempotent consumer` is an essential factor in HTTP idempotency. The API server would need a way to recognize subsequent retries of the same request. Commonly, the consumer generates a unique value, called [idempotency-key](https://tools.ietf.org/id/draft-idempotency-header-01.html#section-2), which the API server uses for that purpose. In addition, when building an idempotent consumer, it is recommended to:
+The creation of an `idempotent consumer` is an essential factor in HTTP idempotency. The API server would need a way to recognize subsequent retries of the same request. Commonly, the consumer generates a unique value, called [idempotency-key](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/), which the API server uses for that purpose. In addition, when building an idempotent consumer, it is recommended to:
 
 - Use "[V4 UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier)" for the creation of the idempotency unique keys (e.g. “07cd2d27-e0dc-466f-8193-28453e9c3023”).
 - Use techniques like the [exponential backoff and random jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/), i.e., including an exponential and random delay between continuous requests.

--- a/src/IdempotentAPI.MinimalAPI/IdempotentAPI.MinimalAPI.csproj
+++ b/src/IdempotentAPI.MinimalAPI/IdempotentAPI.MinimalAPI.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<Authors>Ioannis Kyriakidis</Authors>
 		<Company>ikyriakidis.com</Company>
-		<Version>2.2.0</Version>
+		<Version>3.0.0-prerelease-01</Version>
 		<Description>IdempotentAPI support in Minimal APIs.</Description>
 		<PackageTags>cache;idempotent api;idempotency;asp.net core;attribute;middleware;rest</PackageTags>
 		<RepositoryUrl>https://github.com/ikyriak/IdempotentAPI.git</RepositoryUrl>

--- a/src/IdempotentAPI.MinimalAPI/IdempotentAPI.MinimalAPI.csproj
+++ b/src/IdempotentAPI.MinimalAPI/IdempotentAPI.MinimalAPI.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<Authors>Ioannis Kyriakidis</Authors>
 		<Company>ikyriakidis.com</Company>
-		<Version>3.0.0-prerelease-01</Version>
+		<Version>3.0.0</Version>
 		<Description>IdempotentAPI support in Minimal APIs.</Description>
 		<PackageTags>cache;idempotent api;idempotency;asp.net core;attribute;middleware;rest</PackageTags>
 		<RepositoryUrl>https://github.com/ikyriak/IdempotentAPI.git</RepositoryUrl>

--- a/src/IdempotentAPI.MinimalAPI/IdempotentAPIEndpointFilter.cs
+++ b/src/IdempotentAPI.MinimalAPI/IdempotentAPIEndpointFilter.cs
@@ -16,8 +16,7 @@ public class IdempotentAPIEndpointFilter : IEndpointFilter
 {
     private readonly IServiceProvider _serviceProvider;
 
-    public IdempotentAPIEndpointFilter(
-        IServiceProvider serviceProvider)
+    public IdempotentAPIEndpointFilter(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
     }

--- a/src/IdempotentAPI/Core/Idempotency.cs
+++ b/src/IdempotentAPI/Core/Idempotency.cs
@@ -172,7 +172,11 @@ namespace IdempotentAPI.Core
                 return;
             }
 
-            string requestsDataHash = GenerateRequestsDataHashMinimalApi(arguments, httpContext.Request);
+            // Remove the HttpRequest because it causes a self-referencing loop when serializing.
+            // In addition, the HttpRequest is unnecessary to generate the request's data hash.
+            var filteredArguments = arguments.Where(a => a is not HttpRequest);
+
+            string requestsDataHash = GenerateRequestsDataHashMinimalApi(filteredArguments, httpContext.Request);
 
             httpContext.SetRequestsDataHash(requestsDataHash);
         }
@@ -464,7 +468,7 @@ namespace IdempotentAPI.Core
             return serializedCacheData;
         }
 
-        private string GenerateRequestsDataHashMinimalApi(IList<object?> arguments, HttpRequest httpRequest)
+        private string GenerateRequestsDataHashMinimalApi(IEnumerable<object?> arguments, HttpRequest httpRequest)
         {
             List<object?> requestsData = new(arguments);
 

--- a/src/IdempotentAPI/Extensions/DependencyInjection/IdempotentAPIExtensions.cs
+++ b/src/IdempotentAPI/Extensions/DependencyInjection/IdempotentAPIExtensions.cs
@@ -1,5 +1,8 @@
-﻿using IdempotentAPI.AccessCache;
+﻿using System;
+using IdempotentAPI.AccessCache;
+using IdempotentAPI.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace IdempotentAPI.Extensions.DependencyInjection
 {
@@ -13,6 +16,35 @@ namespace IdempotentAPI.Extensions.DependencyInjection
         public static IServiceCollection AddIdempotentAPI(this IServiceCollection serviceCollection)
         {
             serviceCollection.AddSingleton<IIdempotencyAccessCache, IdempotencyAccessCache>();
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Register the Core services that are required by the IdempotentAPI for Minimal APIs.
+        /// </summary>
+        /// <param name="serviceCollection"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddIdempotentMinimalAPI(this IServiceCollection serviceCollection, IdempotencyOptions idempotencyOptions)
+        {
+            serviceCollection.AddSingleton<IIdempotencyAccessCache, IdempotencyAccessCache>();
+            serviceCollection.AddSingleton<IIdempotencyOptions>(idempotencyOptions);
+            serviceCollection.AddTransient(serviceProvider =>
+            {
+                var distributedCache = serviceProvider.GetRequiredService<IIdempotencyAccessCache>();
+                var logger = serviceProvider.GetRequiredService<ILogger<Idempotency>>();
+                var idempotencyOptions = serviceProvider.GetRequiredService<IIdempotencyOptions>();
+
+                return new Idempotency(
+                    distributedCache,
+                    logger,
+                    idempotencyOptions.ExpiresInMilliseconds,
+                    idempotencyOptions.HeaderKeyName,
+                    idempotencyOptions.DistributedCacheKeysPrefix,
+                    TimeSpan.FromMilliseconds(idempotencyOptions.DistributedLockTimeoutMilli),
+                    idempotencyOptions.CacheOnlySuccessResponses,
+                    idempotencyOptions.IsIdempotencyOptional);
+            });
 
             return serviceCollection;
         }

--- a/src/IdempotentAPI/IdempotentAPI.csproj
+++ b/src/IdempotentAPI/IdempotentAPI.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <Authors>Ioannis Kyriakidis</Authors>
         <Company>ikyriakidis.com</Company>
-        <Version>2.3.0-prerelease-01</Version>
+        <Version>2.3.0</Version>
         <Description>IdempotentAPI is an ASP.NET Core attribute by which any HTTP write operations (POST and PATCH) can have effect only once for the given request data.</Description>
         <PackageTags>idempotent api;idempotency;asp.net core;attribute;middleware;rest</PackageTags>
         <RepositoryUrl>https://github.com/ikyriak/IdempotentAPI.git</RepositoryUrl>

--- a/src/IdempotentAPI/IdempotentAPI.csproj
+++ b/src/IdempotentAPI/IdempotentAPI.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <Authors>Ioannis Kyriakidis</Authors>
         <Company>ikyriakidis.com</Company>
-        <Version>2.2.0</Version>
+        <Version>2.2.1-prerelease-01</Version>
         <Description>IdempotentAPI is an ASP.NET Core attribute by which any HTTP write operations (POST and PATCH) can have effect only once for the given request data.</Description>
         <PackageTags>idempotent api;idempotency;asp.net core;attribute;middleware;rest</PackageTags>
         <RepositoryUrl>https://github.com/ikyriak/IdempotentAPI.git</RepositoryUrl>

--- a/src/IdempotentAPI/IdempotentAPI.csproj
+++ b/src/IdempotentAPI/IdempotentAPI.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <Authors>Ioannis Kyriakidis</Authors>
         <Company>ikyriakidis.com</Company>
-        <Version>2.2.1-prerelease-01</Version>
+        <Version>2.3.0-prerelease-01</Version>
         <Description>IdempotentAPI is an ASP.NET Core attribute by which any HTTP write operations (POST and PATCH) can have effect only once for the given request data.</Description>
         <PackageTags>idempotent api;idempotency;asp.net core;attribute;middleware;rest</PackageTags>
         <RepositoryUrl>https://github.com/ikyriak/IdempotentAPI.git</RepositoryUrl>

--- a/tests/IdempotentAPI.TestWebMinimalAPIs/IdempotentAPI.TestWebMinimalAPIs.csproj
+++ b/tests/IdempotentAPI.TestWebMinimalAPIs/IdempotentAPI.TestWebMinimalAPIs.csproj
@@ -18,7 +18,6 @@
 		<ProjectReference Include="..\..\src\IdempotentAPI.DistributedAccessLock.MadelsonDistributedLock\IdempotentAPI.DistributedAccessLock.MadelsonDistributedLock.csproj" />
 		<ProjectReference Include="..\..\src\IdempotentAPI.DistributedAccessLock.RedLockNet\IdempotentAPI.DistributedAccessLock.RedLockNet.csproj" />
 		<ProjectReference Include="..\..\src\IdempotentAPI.MinimalAPI\IdempotentAPI.MinimalAPI.csproj" />
-		<ProjectReference Include="..\..\src\IdempotentAPI\IdempotentAPI.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/tests/IdempotentAPI.TestWebMinimalAPIs/Program.cs
+++ b/tests/IdempotentAPI.TestWebMinimalAPIs/Program.cs
@@ -92,7 +92,7 @@ app.MapPost("/v6/TestingIdempotentAPI/test", () =>
     })
     .AddEndpointFilter<IdempotentAPIEndpointFilter>();
 
-app.MapPost("/v6/TestingIdempotentAPI/testobject", () =>
+app.MapPost("/v6/TestingIdempotentAPI/testobject", (HttpRequest httpRequest) =>
     {
         return new ResponseDTOs();
     })
@@ -111,7 +111,7 @@ app.MapPost("/v6/TestingIdempotentOptionalAPI/testobject", () =>
     .AddEndpointFilter<IdempotentAPIEndpointFilter>();
 
 app.MapPost("/v6/TestingIdempotentAPI/testobjectbody",
-    ([FromBody] RequestDTOs requestDTOs) =>
+    ([FromBody] RequestDTOs requestDTOs, HttpRequest httpRequest) =>
     {
         return new ResponseDTOs()
         {

--- a/tests/IdempotentAPI.TestWebMinimalAPIs/Program.cs
+++ b/tests/IdempotentAPI.TestWebMinimalAPIs/Program.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Security.Claims;
 using IdempotentAPI.Cache.DistributedCache.Extensions.DependencyInjection;
 using IdempotentAPI.Cache.FusionCache.Extensions.DependencyInjection;
 using IdempotentAPI.Core;
@@ -92,7 +93,13 @@ app.MapPost("/v6/TestingIdempotentAPI/test", () =>
     })
     .AddEndpointFilter<IdempotentAPIEndpointFilter>();
 
-app.MapPost("/v6/TestingIdempotentAPI/testobject", (HttpRequest httpRequest) =>
+app.MapPost("/v6/TestingIdempotentAPI/testobject", (
+    HttpRequest httpRequest,
+    HttpContext context,
+    HttpResponse response,
+    ClaimsPrincipal user,
+    CancellationToken cancellationToken
+    ) =>
     {
         return new ResponseDTOs();
     })
@@ -111,7 +118,13 @@ app.MapPost("/v6/TestingIdempotentOptionalAPI/testobject", () =>
     .AddEndpointFilter<IdempotentAPIEndpointFilter>();
 
 app.MapPost("/v6/TestingIdempotentAPI/testobjectbody",
-    ([FromBody] RequestDTOs requestDTOs, HttpRequest httpRequest) =>
+    ([FromBody] RequestDTOs requestDTOs,
+    HttpRequest httpRequest,
+    HttpContext context,
+    HttpResponse response,
+    ClaimsPrincipal user,
+    CancellationToken cancellationToken
+    ) =>
     {
         return new ResponseDTOs()
         {

--- a/tests/IdempotentAPI.TestWebMinimalAPIs/Program.cs
+++ b/tests/IdempotentAPI.TestWebMinimalAPIs/Program.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Security.Claims;
-using IdempotentAPI.AccessCache;
 using IdempotentAPI.Cache.DistributedCache.Extensions.DependencyInjection;
 using IdempotentAPI.Cache.FusionCache.Extensions.DependencyInjection;
 using IdempotentAPI.Core;
@@ -17,26 +16,30 @@ using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddIdempotentAPI();
 
-// This is REQUIRED for Minimal APIs to configure the Idempotency:
-builder.Services.AddSingleton<IIdempotencyOptions, IdempotencyOptions>();
-builder.Services.AddTransient(serviceProvider =>
-{
-    var distributedCache = serviceProvider.GetRequiredService<IIdempotencyAccessCache>();
-    var logger = serviceProvider.GetRequiredService<ILogger<Idempotency>>();
-    var idempotencyOptions = serviceProvider.GetRequiredService<IIdempotencyOptions>();
+builder.Services.AddIdempotentMinimalAPI(new IdempotencyOptions());
 
-    return new Idempotency(
-        distributedCache,
-        logger,
-        idempotencyOptions.ExpiresInMilliseconds,
-        idempotencyOptions.HeaderKeyName,
-        idempotencyOptions.DistributedCacheKeysPrefix,
-        TimeSpan.FromMilliseconds(idempotencyOptions.DistributedLockTimeoutMilli),
-        idempotencyOptions.CacheOnlySuccessResponses,
-        idempotencyOptions.IsIdempotencyOptional);
-});
+// FYI: The following commended code was replaced by the AddIdempotentMinimalAPI(...) extension above.
+//builder.Services.AddIdempotentAPI();
+
+//// This is REQUIRED for Minimal APIs to configure the Idempotency:
+//builder.Services.AddSingleton<IIdempotencyOptions, IdempotencyOptions>();
+//builder.Services.AddTransient(serviceProvider =>
+//{
+//    var distributedCache = serviceProvider.GetRequiredService<IIdempotencyAccessCache>();
+//    var logger = serviceProvider.GetRequiredService<ILogger<Idempotency>>();
+//    var idempotencyOptions = serviceProvider.GetRequiredService<IIdempotencyOptions>();
+
+//    return new Idempotency(
+//        distributedCache,
+//        logger,
+//        idempotencyOptions.ExpiresInMilliseconds,
+//        idempotencyOptions.HeaderKeyName,
+//        idempotencyOptions.DistributedCacheKeysPrefix,
+//        TimeSpan.FromMilliseconds(idempotencyOptions.DistributedLockTimeoutMilli),
+//        idempotencyOptions.CacheOnlySuccessResponses,
+//        idempotencyOptions.IsIdempotencyOptional);
+//});
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(x =>


### PR DESCRIPTION
Fix for Minimal API: When the[ special types](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?view=aspnetcore-8.0#special-types) (such as `HttpRequest`) are used as arguments, a Newtonsoft serialization exception for a self-referencing loop is thrown. The primary exception information is the following. 